### PR TITLE
Add restaurant name to restaurant_reviews table. change store method …

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -42,7 +42,9 @@ class HomeController extends Controller
 
         // 🔥 Google API からレストランの情報（写真・名前）を取得
         foreach ($popularRestaurants as $restaurant) {
-            $restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
+            $restaurant->restaurant_name = RestaurantReview::where('place_id', $restaurant->place_id)
+            ->first()?->restaurant_name ?? 'Unknown Restaurant';
+            //$restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
             $restaurant->photo = $this->getRestaurantPhotoFromGoogleAPI($restaurant->place_id);
             $restaurant->average_rate = round($restaurant->average_rate, 1) ?? 0; // ⭐ 平均評価を四捨五入
             $favorite = FavoriteRestaurant::where('user_id', Auth::id())

--- a/app/Http/Controllers/MypageController.php
+++ b/app/Http/Controllers/MypageController.php
@@ -20,7 +20,9 @@ class MypageController extends Controller
         $topRestaurantReviews = $user->reviews()->latest()->limit(3)->get();
 
         foreach ($topRestaurantReviews as $review) {
-            $review->restaurant_name = $this->getRestaurantNameFromGoogleAPI($review->place_id);
+            $review->restaurant_name = RestaurantReview::where('place_id', $review->place_id)
+            ->first()?->restaurant_name ?? 'Unknown Restaurant';
+            // $review->restaurant_name = $this->getRestaurantNameFromGoogleAPI($review->place_id);
         }
 
         return view('mypage.index', compact('user', 'itineraries', 'restaurantReviews','topRestaurantReviews'));
@@ -34,7 +36,9 @@ class MypageController extends Controller
         $restaurantReviews = RestaurantReview::where('user_id', $userId)->latest()->get();
 
         foreach ($topRestaurantReviews as $review) {
-            $review->restaurant_name = $this->getRestaurantNameFromGoogleAPI($review->place_id);
+            $review->restaurant_name = RestaurantReview::where('place_id', $review->place_id)
+            ->first()?->restaurant_name ?? 'Unknown Restaurant';
+            // $review->restaurant_name = $this->getRestaurantNameFromGoogleAPI($review->place_id);
         }
 
         // 必要なデータをビューに渡す

--- a/app/Http/Controllers/RegionController.php
+++ b/app/Http/Controllers/RegionController.php
@@ -31,7 +31,9 @@ class RegionController extends Controller
 
     // 🔥 各 `place_id` について Google API からレストラン名を取得
     foreach ($popularRestaurants as $restaurant) {
-        $restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
+        $restaurant->restaurant_name = RestaurantReview::where('place_id', $restaurant->place_id)
+            ->first()?->restaurant_name ?? 'Unknown Restaurant';
+        //$restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
         $restaurant->photo = $this->getRestaurantPhotoFromGoogleAPI($restaurant->place_id);
         $restaurant->average_rate = round($restaurant->average_rate, 1) ?? 0; // ⭐ 平均評価を四捨五入
     }
@@ -77,7 +79,9 @@ class RegionController extends Controller
             ->get();
 
         foreach ($allRestaurants as $restaurant) {
-            $restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
+            $restaurant->restaurant_name = RestaurantReview::where('place_id', $restaurant->place_id)
+            ->first()?->restaurant_name ?? 'Unknown Restaurant';
+            //$restaurant->name = $this->getRestaurantNameFromGoogleAPI($restaurant->place_id);
             $restaurant->photo = $this->getRestaurantPhotoFromGoogleAPI($restaurant->place_id);
             $restaurant->average_rate = round($restaurant->average_rate, 1) ?? 0; // ⭐ 平均評価を四捨五入
         }

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -43,24 +43,33 @@ class ReviewController extends Controller
     //     return view('reviews.mylist', ['reviews' => $reviews]);
     // }
 
+    // public function myList(Request $request)
+    // {
+    //     $reviews = RestaurantReview::where('user_id', Auth::id())->get();
+
+    //     foreach ($reviews as $review) {
+    //         $review->restaurant_name = Cache::remember("restaurant_name_{$review->place_id}", now()->addHours(6), function () use ($review) {
+    //             \Log::info("Google API Request: Fetching name for {$review->place_id}"); // ログ追加
+
+    //             $apiKey = env('GOOGLE_MAPS_API_KEY');
+    //             $apiUrl = "https://maps.googleapis.com/maps/api/place/details/json?placeid={$review->place_id}&key={$apiKey}&language=en";
+
+    //             $response = Http::get($apiUrl);
+    //             $data = $response->json();
+
+    //             return $data['result']['name'] ?? 'Unknown Restaurant';
+    //         });
+    //     }
+
+    //     return view('reviews.mylist', ['reviews' => $reviews]);
+    // }
+
     public function myList(Request $request)
     {
+        // 自分のレビューを取得（restaurant_name もすでに含まれてる）
         $reviews = RestaurantReview::where('user_id', Auth::id())->get();
 
-        foreach ($reviews as $review) {
-            $review->restaurant_name = Cache::remember("restaurant_name_{$review->place_id}", now()->addHours(6), function () use ($review) {
-                \Log::info("Google API Request: Fetching name for {$review->place_id}"); // ログ追加
-
-                $apiKey = env('GOOGLE_MAPS_API_KEY');
-                $apiUrl = "https://maps.googleapis.com/maps/api/place/details/json?placeid={$review->place_id}&key={$apiKey}&language=en";
-
-                $response = Http::get($apiUrl);
-                $data = $response->json();
-
-                return $data['result']['name'] ?? 'Unknown Restaurant';
-            });
-        }
-
+        // すでにDBにあるrestaurant_nameを使えばOKなので、何も追加処理はいらない！
         return view('reviews.mylist', ['reviews' => $reviews]);
     }
 

--- a/app/Models/RestaurantReview.php
+++ b/app/Models/RestaurantReview.php
@@ -19,6 +19,7 @@ class RestaurantReview extends Model
         'title',
         'body',
         'photo', // メイン画像
+        'restaurant_name', 
     ];
 
     public function prefecture()

--- a/database/migrations/2025_03_22_082345_add_restaurant_name_to_restaurant_reviews_table.php
+++ b/database/migrations/2025_03_22_082345_add_restaurant_name_to_restaurant_reviews_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('restaurant_reviews', function (Blueprint $table) {
+            $table->string('restaurant_name')->nullable()->after('place_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('restaurant_reviews', function (Blueprint $table) {
+            $table->dropColumn('restaurant_name');
+        });
+    }
+};

--- a/resources/views/Regions/home.blade.php
+++ b/resources/views/Regions/home.blade.php
@@ -69,12 +69,12 @@
                             <div class="custom-card">
                                 <div class="card-image d-flex justify-content-center align-items-center">
                                     <img src="{{ $restaurant->photo }}" 
-                                    alt="{{ $restaurant->name }}" 
+                                    alt="{{ $restaurant->restaurant_name }}" 
                                     class="rounded img-fluid">
                                 </div>
                                 <div class="card-content ms-3">
                                     
-                                    <h5>{{ $restaurant->name }}</h5>
+                                    <h5>{{ $restaurant->restaurant_name }}</h5>
                                     
                                     <!-- ⭐ 評価（星）表示 -->
                                     <div class="d-flex align-items-center mb-2">

--- a/resources/views/Regions/restaurant_review.blade.php
+++ b/resources/views/Regions/restaurant_review.blade.php
@@ -30,12 +30,12 @@
                     <div class="custom-card">
                         <div class="card-image d-flex justify-content-center align-items-center">
                             <img src="{{ $restaurant->photo }}" 
-                            alt="{{ $restaurant->name }}" 
+                            alt="{{ $restaurant->restaurant_name }}" 
                             class="rounded img-fluid">
                         </div>
                         <div class="card-content ms-3">
                             
-                            <h5>{{ $restaurant->name }}</h5>
+                            <h5>{{ $restaurant->restaurant_name }}</h5>
                             
                             <!-- ⭐ 評価（星）表示 -->
                             <div class="d-flex align-items-center mb-2">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -91,7 +91,7 @@
                 <div class="col-4">
                     <div class="card shadow-sm border-0 w-100 rounded-4 position-relative">
                         <!-- レストラン画像 -->
-                        <img src="{{ $restaurant->photo }}" alt="{{ $restaurant->name }}" class="rounded-top-4 img-fluid"
+                        <img src="{{ $restaurant->photo }}" alt="{{ $restaurant->restaurant_name }}" class="rounded-top-4 img-fluid"
                             style="height: 200px; object-fit: cover;">
 
                         @auth <!-- ログインしている場合のみお気に入り機能を表示 -->
@@ -112,7 +112,7 @@
 
                         <div class="card-body p-2">
                             <h6 class="card-title mb-1 fw-bold" style="font-size: 14px;">
-                                {{ $restaurant->name }}
+                                {{ $restaurant->restaurant_name }}
                             </h6>
                             <h6>
                                 <span class="restaurant-rating">{{ number_format($restaurant->average_rate, 1) }}</span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -99,23 +99,23 @@
                     </header>
 
                     <!-- Search Bar -->
-                    <div class="search-bar ms-3">
+                    <form action="{{ route('restaurants.search') }}" method="GET" class="search-bar ms-3">
                         <div class="input-group">
-                            <select class="form-select rounded-start"
+                            <select name="type" class="form-select rounded-start"
                                 style="width: 100px!important; background-color: #ffe59d;">
                                 <option value="all">Select</option>
                                 <option value="itinerary">Itinerary</option>
                                 <option value="review">Restaurant's Review</option>
                             </select>
 
-                            <input type="text" class="form-control" style="width: 180px!important;"
+                            <input type="text" name="keyword" class="form-control" style="width: 180px!important;"
                                 placeholder="Search here...">
 
-                            <button class="btn btn-outline-secondary" type="button">
+                            <button class="btn btn-outline-secondary" type="submit">
                                 <i class="fas fa-search"></i>
                             </button>
                         </div>
-                    </div>
+                    </form>
                 </div>
 
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"

--- a/resources/views/mypage/index.blade.php
+++ b/resources/views/mypage/index.blade.php
@@ -263,7 +263,9 @@
                                         </div>
                                         <div class="col-md-9">
                                             <div class="card-body">
-                                                <h6 class="restaurant-name" data-place-id="{{ $review->place_id }}" style="font-weight: bold; color: #E97911;">Loading...</h6>
+                                                <h6 style="font-weight: bold; color: #E97911;">
+                                                    {{ $review->restaurant_name ?? 'Unknown' }}
+                                                </h6>
                                                 <h5 class="card-title fw-bold">{{ $review->title }}</h5>
                                                 <p class="card-text">
                                                     @for ($i = 0; $i < 5; $i++)

--- a/resources/views/mypage/show_others.blade.php
+++ b/resources/views/mypage/show_others.blade.php
@@ -264,7 +264,9 @@
                                         </div>
                                         <div class="col-md-9">
                                             <div class="card-body">
-                                                <h6 class="restaurant-name" data-place-id="{{ $review->place_id }}" style="font-weight: bold; color: #E97911;">Loading...</h6>
+                                                <h6 class="restaurant-name" style="font-weight: bold; color: #E97911;">
+                                                    {{ $review->restaurant_name ?? 'Unknown' }}
+                                                </h6>
                                                 <h5 class="card-title fw-bold">{{ $review->title }}</h5>
                                                 <p class="card-text">
                                                     @for ($i = 0; $i < 5; $i++)
@@ -295,7 +297,7 @@
                             </div>
                         @endforeach
                     @else
-                        <p class="text-center">No Restaurant Reviews Yet.</p>
+                        <p class="text-center">No Restaurant Reviews</p>
                     @endif
                     </div>
         

--- a/resources/views/reviews/mylist.blade.php
+++ b/resources/views/reviews/mylist.blade.php
@@ -12,7 +12,7 @@
         </div>
 
         <!-- 📜 レビュー一覧 -->
-        <div class="row">
+        <div class="row mb-3">
             @if (count($reviews) > 0)
                 @foreach ($reviews as $review)
                     <div class="col-md-12 position-relative review-container">
@@ -35,7 +35,7 @@
                                 <div>
                                     <!-- レストラン名 & Rating を横並びに配置 -->
                                     <div class="d-flex align-items-center">
-                                        <h5 class="card-title mb-0">{{ $review->restaurant_name }}</h5>
+                                        <h5 class="card-title mb-0">{{ $review->restaurant_name ?? 'Unknown' }}</h5>
                                         <p class="text-warning mb-0 ms-3">
                                             @for ($i = 0; $i < $review->rating; $i++)
                                                 <i class="fa-solid fa-circle text-warning"></i>


### PR DESCRIPTION
Since calling the Google API every time to get the restaurant name takes time, I’ve modified the system to save the restaurant name when a review is registered. From now on, the restaurant name will be retrieved from the database instead of relying on the Google API. I've already asked Mike to make restaurant_name column and use this.
The reasons for this change are:

Without the restaurant_name in the table, it's difficult to implement keyword search.

Every time we retrieve the restaurant name, it requires a call to the Google API, which causes slow loading times.